### PR TITLE
irc.js : certains messages de salon ne s'affichent pas

### DIFF
--- a/js/irc.js
+++ b/js/irc.js
@@ -1632,7 +1632,7 @@ function msg(raw) {
 		hlcolor = 'hlcolor';
 	}
 	
-	let w = document.getElementById('chan_' + chan);
+	let w = document.getElementById('chan_' + chan.toLowerCase());
 	let line = document.createElement('p');
 	
 	line.id = 'idmsg_' + idmsg;


### PR DESCRIPTION
La recherche de la fenêtre dans laquelle afficher le message peut ne pas aboutir si le client distant a une majuscule dans le nom du salon.