### PR TITLE
Fix bug for "_" in channel name.

### DIFF
--- a/js/irc_events.js
+++ b/js/irc_events.js
@@ -641,7 +641,7 @@ let emojiCursor;
 			
 			if (windows.item(index + 1).id !== 'status') {
 				
-				let target = windows.item(index + 1).id.split('_');
+				let target = windows.item(index + 1).id.split('_', 1);
 				
 				if (target[0] == 'chan') {
 					


### PR DESCRIPTION
let target = windows.item(index + 1).id.split('_');
change to :
let target = windows.item(index + 1).id.split('_', 1);